### PR TITLE
fix: altera comando de copiar arquivo para funcionar em todos SO

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # POPPLOY
 
-Popploy é um script para automatizar o deploy do bff já que o mesmo necessita ser enviado para um repositório da SEAC para rodar uma pipeline e ser enviado para o servidor, porém já utilizamos um repositório da Popcode que tem uma estrutura de branch diferente, daí surgiu a ideia da criação do script, ele consegue ser usado em qualquer projeto que tenha o mesmo problema sitado acima.
+Popploy é um script para automatizar o deploy do bff já que o mesmo necessita ser enviado para um repositório da SEAC para rodar uma pipeline e ser enviado para o servidor, porém já utilizamos um repositório da Popcode que tem uma estrutura de branch diferente, daí surgiu a ideia da criação do script, ele consegue ser usado em qualquer projeto que tenha o mesmo problema citado acima.
 
 # Getting Started
 

--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,7 @@ const main = async () => {
       .readdirSync(path.resolve(__dirname, "..", "..", "..", clonePath))
       .filter((item) => !repoExclude.includes(item));
 
-    repoFile.forEach((item) => shell.exec(`rm -rf ${item}`));
+    repoFile.forEach((item) => shell.exec(`npx rimraf ${item}`));
 
     const copyFile = fs
       .readdirSync(path.resolve(__dirname, "..", "..", ".."))
@@ -82,7 +82,11 @@ const main = async () => {
     const fileToAdd = copyFile.join(" ");
 
     if (fileToAdd.length !== 0) {
-      shell.exec(`cd .. && cp -r ${fileToAdd} ${clonePath} && cd ${clonePath}`);
+      shell.exec(`cd .. `)
+      copyFile.map((item) => {
+        fs.copyFileSync(path.resolve(__dirname,"..","..", "..", item), item)
+      })
+      shell.exec(`cd ${clonePath}`);
       shell.exec("yarn remove popploy");
       shell.exec("git add .");
       shell.exec(`git commit -m "publish ${version}"`);


### PR DESCRIPTION
# 🏅 Título: Corrige script para funcionar no Windows


#### 📋 Descrição: 
A alteração foi feita por conta de os comandos "rm -rf" e "cp -r" não funcionarem no Windows 10, deste modo foi-se utilizada a função copyFileSync do módulo fs do Node para copiar os arquivos e o "rm -rf" substituído pela lib "rimraf" já utilizada no script.


#### 📝 Plano de teste:
- Adicione e configure o popploy em algum projeto
- execute-o em diferentes SO (Windows e outro) e verifique se funciona como esperado