### PR TITLE
Chore/same commands for all operating systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # POPPLOY
 
-Popploy é um script para automatizar o deploy do bff já que o mesmo necessita ser enviado para um repositório da SEAC para rodar uma pipeline e ser enviado para o servidor, porém já utilizamos um repositório da Popcode que tem uma estrutura de branch diferente, daí surgiu a ideia da criação do script, ele consegue ser usado em qualquer projeto que tenha o mesmo problema citado acima.
+Popploy é um script para automatizar o deploy do bff já que o mesmo necessita ser enviado para um repositório da SEAC para rodar uma pipeline e ser enviado para o servidor, porém já utilizamos um repositório da Popcode que tem uma estrutura de branch diferente, daí surgiu a ideia da criação do script, ele consegue ser usado em qualquer projeto que tenha o mesmo problema sitado acima.
 
 # Getting Started
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # POPPLOY
 
-Popploy é um script para automatizar o deploy do bff já que o mesmo necessita ser enviado para um repositório da SEAC para rodar uma pipeline e ser enviado para o servidor, porém já utilizamos um repositório da Popcode que tem uma estrutura de branch diferente, daí surgiu a ideia da criação do script, ele consegue ser usado em qualquer projeto que tenha o mesmo problema sitado acima.
+Popploy é um script para automatizar o deploy do bff já que o mesmo necessita ser enviado para um repositório da SEAC para rodar uma pipeline e ser enviado para o servidor, porém já utilizamos um repositório da Popcode que tem uma estrutura de branch diferente, daí surgiu a ideia da criação do script, ele consegue ser usado em qualquer projeto que tenha o mesmo problema citado acima.
 
 # Getting Started
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
+    "fs-extra": "^10.1.0",
     "minimist": "^1.2.6",
     "rimraf": "^3.0.2",
     "shelljs": "^0.8.5"

--- a/src/index.js
+++ b/src/index.js
@@ -85,7 +85,7 @@ const main = async () => {
     if (fileToAdd.length !== 0) {
       shell.exec(`cd .. `)
       copyFile.map((item) => {
-        fsExtra.copy(path.resolve(__dirname,"..","..", "..", item), item)
+        fsExtra.copySync(path.resolve(__dirname,"..","..", "..", item), item)
       })
       shell.exec(`cd ${clonePath}`);
       shell.exec("yarn remove popploy");

--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,7 @@ const main = async () => {
       .readdirSync(path.resolve(__dirname, "..", "..", "..", clonePath))
       .filter((item) => !repoExclude.includes(item));
 
-    repoFile.forEach((item) => shell.exec(`npx rimraf ${item}`));
+    repoFile.forEach((item) => shell.exec(`rm -rf ${item}`));
 
     const copyFile = fs
       .readdirSync(path.resolve(__dirname, "..", "..", ".."))
@@ -82,11 +82,7 @@ const main = async () => {
     const fileToAdd = copyFile.join(" ");
 
     if (fileToAdd.length !== 0) {
-      shell.exec(`cd .. `)
-      copyFile.map((item) => {
-        fs.copyFileSync(path.resolve(__dirname,"..","..", "..", item), item)
-      })
-      shell.exec(`cd ${clonePath}`);
+      shell.exec(`cd .. && cp -r ${fileToAdd} ${clonePath} && cd ${clonePath}`);
       shell.exec("yarn remove popploy");
       shell.exec("git add .");
       shell.exec(`git commit -m "publish ${version}"`);

--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,7 @@ const main = async () => {
       .readdirSync(path.resolve(__dirname, "..", "..", "..", clonePath))
       .filter((item) => !repoExclude.includes(item));
 
-    repoFile.forEach((item) => shell.exec(`rm -rf ${item}`));
+    repoFile.forEach((item) => shell.exec(`npx rimraf ${item}`));
 
     const copyFile = fs
       .readdirSync(path.resolve(__dirname, "..", "..", ".."))
@@ -82,7 +82,11 @@ const main = async () => {
     const fileToAdd = copyFile.join(" ");
 
     if (fileToAdd.length !== 0) {
-      shell.exec(`cd .. && cp -r ${fileToAdd} ${clonePath} && cd ${clonePath}`);
+      shell.exec(`cd .. `)
+      copyFile.map((item) => {
+        fs.copyFileSync(path.resolve(__dirname,"..","..", "..", item), item)
+      })
+      shell.exec(`cd ${clonePath}`);
       shell.exec("yarn remove popploy");
       shell.exec("git add .");
       shell.exec(`git commit -m "publish ${version}"`);

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 const shell = require("shelljs");
 const fs = require("fs");
 const path = require("path");
+const fsExtra = require("fs-extra");
 
 const updateVersion = require("./update-version");
 const getValue = require("./get-value");
@@ -74,7 +75,7 @@ const main = async () => {
       .readdirSync(path.resolve(__dirname, "..", "..", "..", clonePath))
       .filter((item) => !repoExclude.includes(item));
 
-    repoFile.forEach((item) => shell.exec(`rm -rf ${item}`));
+    repoFile.forEach((item) => shell.exec(`npx rimraf ${item}`));
 
     const copyFile = fs
       .readdirSync(path.resolve(__dirname, "..", "..", ".."))
@@ -82,7 +83,11 @@ const main = async () => {
     const fileToAdd = copyFile.join(" ");
 
     if (fileToAdd.length !== 0) {
-      shell.exec(`cd .. && cp -r ${fileToAdd} ${clonePath} && cd ${clonePath}`);
+      shell.exec(`cd .. `)
+      copyFile.map((item) => {
+        fsExtra.copy(path.resolve(__dirname,"..","..", "..", item), item)
+      })
+      shell.exec(`cd ${clonePath}`);
       shell.exec("yarn remove popploy");
       shell.exec("git add .");
       shell.exec(`git commit -m "publish ${version}"`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,6 +20,15 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
+fs-extra@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.1.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"
+  integrity sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -41,6 +50,11 @@ glob@^7.0.0, glob@^7.1.3:
     minimatch "^3.1.1"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+graceful-fs@^4.1.6, graceful-fs@^4.2.0:
+  version "4.2.10"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
+  integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
 has@^1.0.3:
   version "1.0.3"
@@ -73,6 +87,15 @@ is-core-module@^2.8.1:
   integrity sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==
   dependencies:
     has "^1.0.3"
+
+jsonfile@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
+  integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
+  dependencies:
+    universalify "^2.0.0"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
 
 minimatch@^3.1.1:
   version "3.1.2"
@@ -139,6 +162,11 @@ supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
+
+universalify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
+  integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
# 🏅 Título: Corrige script para funcionar no Windows


#### 📋 Descrição: 
A alteração foi feita por conta de os comandos "rm -rf" e "cp -r" não funcionarem no Windows 10, deste modo foi-se utilizada a função copySync do módulo fs-extra para copiar os arquivos e pastas e o "rm -rf" substituído pela lib "rimraf" já utilizada no script.


#### 📝 Plano de teste:
- Adicione e configure o popploy em algum projeto
- execute-o em diferentes SO (Windows e outro) e verifique se funciona como esperado

sugestão: teste no BFF, crie uma branch para teste, altere o gitUrl do popploy.json para um repositório pessoal e execute o script
